### PR TITLE
Add JWT authentication and profile endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Server/bin/
+Server/obj/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains a minimal skeleton for a shopping web application.
 It includes:
 
-- **Server**: an ASP.NET Core 8 Web API project with simple registration and login endpoints using an in-memory EF Core database.
+- **Server**: an ASP.NET Core 8 Web API project with registration, login and basic profile endpoints using an in-memory EF Core database and JWT authentication.
 - **client**: a placeholder React TypeScript project.
 
 ## Running the server
@@ -14,9 +14,10 @@ dotnet run --project Server/Server.csproj
 
 The API exposes:
 - `POST /api/register` – register a user with `FullName`, `Email`, and `Password`.
-- `POST /api/login` – login with `Email` and `Password`.
-
-Both endpoints return basic responses and do not implement JWT authentication yet.
+- `POST /api/login` – login with `Email` and `Password` and receive a JWT token.
+- `GET /api/profile` – get the authenticated user's profile (requires JWT).
+- `PUT /api/profile` – update the authenticated user's profile (requires JWT).
+- `POST /api/change-password` – change the authenticated user's password (requires JWT).
 
 ## Client
 

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -1,7 +1,32 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
 using Server.Data;
 using Server.Models;
 using BCrypt.Net;
+
+string GenerateJwtToken(User user, string secret)
+{
+    var tokenHandler = new JwtSecurityTokenHandler();
+    var key = Encoding.ASCII.GetBytes(secret);
+    var descriptor = new SecurityTokenDescriptor
+    {
+        Subject = new ClaimsIdentity(new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
+            new Claim(ClaimTypes.Name, user.FullName),
+            new Claim(ClaimTypes.Email, user.Email)
+        }),
+        Expires = DateTime.UtcNow.AddHours(1),
+        SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)
+    };
+
+    var token = tokenHandler.CreateToken(descriptor);
+    return tokenHandler.WriteToken(token);
+}
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -14,6 +39,23 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+var jwtSecret = builder.Configuration["JwtSecret"] ?? "supersecret";
+var key = Encoding.ASCII.GetBytes(jwtSecret);
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = false,
+            ValidateAudience = false,
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey = new SymmetricSecurityKey(key)
+        };
+    });
+
+builder.Services.AddAuthorization();
+
 var app = builder.Build();
 
 if (app.Environment.IsDevelopment())
@@ -23,6 +65,8 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.MapPost("/api/register", async (ApplicationDbContext db, UserDto userDto) =>
 {
@@ -52,12 +96,81 @@ app.MapPost("/api/login", async (ApplicationDbContext db, LoginDto loginDto) =>
         return Results.Unauthorized();
     }
 
-    // For demo purposes we just return a dummy token
-    var token = Convert.ToBase64String(Guid.NewGuid().ToByteArray());
+    var token = GenerateJwtToken(user, jwtSecret);
     return Results.Ok(new { token });
 });
+
+app.MapGet("/api/profile", async (ClaimsPrincipal userPrincipal, ApplicationDbContext db) =>
+{
+    var userIdClaim = userPrincipal.FindFirst(ClaimTypes.NameIdentifier);
+    if (userIdClaim == null)
+    {
+        return Results.Unauthorized();
+    }
+
+    if (!int.TryParse(userIdClaim.Value, out var userId))
+    {
+        return Results.Unauthorized();
+    }
+
+    var user = await db.Users.FindAsync(userId);
+    if (user == null)
+    {
+        return Results.NotFound();
+    }
+
+    return Results.Ok(new { user.Id, user.FullName, user.Email });
+}).RequireAuthorization();
+
+app.MapPut("/api/profile", async (ClaimsPrincipal userPrincipal, ApplicationDbContext db, UpdateUserDto updateDto) =>
+{
+    var userIdClaim = userPrincipal.FindFirst(ClaimTypes.NameIdentifier);
+    if (userIdClaim == null || !int.TryParse(userIdClaim.Value, out var userId))
+    {
+        return Results.Unauthorized();
+    }
+
+    var user = await db.Users.FindAsync(userId);
+    if (user == null)
+    {
+        return Results.NotFound();
+    }
+
+    user.FullName = updateDto.FullName ?? user.FullName;
+    user.Email = updateDto.Email ?? user.Email;
+    await db.SaveChangesAsync();
+
+    return Results.Ok(new { user.Id, user.FullName, user.Email });
+}).RequireAuthorization();
+
+app.MapPost("/api/change-password", async (ClaimsPrincipal userPrincipal, ApplicationDbContext db, ChangePasswordDto dto) =>
+{
+    var userIdClaim = userPrincipal.FindFirst(ClaimTypes.NameIdentifier);
+    if (userIdClaim == null || !int.TryParse(userIdClaim.Value, out var userId))
+    {
+        return Results.Unauthorized();
+    }
+
+    var user = await db.Users.FindAsync(userId);
+    if (user == null)
+    {
+        return Results.NotFound();
+    }
+
+    if (!BCrypt.Net.BCrypt.Verify(dto.OldPassword, user.PasswordHash))
+    {
+        return Results.BadRequest("Invalid old password");
+    }
+
+    user.PasswordHash = BCrypt.Net.BCrypt.HashPassword(dto.NewPassword);
+    await db.SaveChangesAsync();
+
+    return Results.Ok();
+}).RequireAuthorization();
 
 app.Run();
 
 record UserDto(string FullName, string Email, string Password);
 record LoginDto(string Email, string Password);
+record UpdateUserDto(string? FullName, string? Email);
+record ChangePasswordDto(string OldPassword, string NewPassword);

--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.18" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.1" />

--- a/Server/appsettings.Development.json
+++ b/Server/appsettings.Development.json
@@ -4,5 +4,6 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  }
+  },
+  "JwtSecret": "MySuperSecretKey"
 }

--- a/Server/appsettings.json
+++ b/Server/appsettings.json
@@ -6,4 +6,5 @@
     }
   },
   "AllowedHosts": "*"
+  ,"JwtSecret": "MySuperSecretKey"
 }


### PR DESCRIPTION
## Summary
- implement JWT authentication and add middleware
- create profile and password change endpoints
- add helper to generate JWT tokens
- include jwt secret in configs
- document new endpoints in README
- ignore build output

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_687c74b7d6cc832896b01e26ec4a2289